### PR TITLE
Version bump

### DIFF
--- a/lib/instrument_all_the_things/instrumentors/tracing.rb
+++ b/lib/instrument_all_the_things/instrumentors/tracing.rb
@@ -11,19 +11,21 @@ module InstrumentAllTheThings
 
     TRACE_WRAPPER = proc do |opts, context|
       opts = if opts == true
-               DEFAULT_TRACE_OPTIONS
+               DEFAULT_TRACE_OPTIONS.dup
              else
                DEFAULT_TRACE_OPTIONS.merge(opts)
              end
 
+      span_name = opts.delete(:span_name)
+
       proc do |klass, next_blk, actual_code|
-        InstrumentAllTheThings.tracer.trace(
-          opts[:span_name],
-          tags: context[:tags] || {},
-          service: opts[:service],
-          resource: opts[:resource] || context.trace_name(klass),
-          span_type: opts[:span_type]
-        ) { next_blk.call(klass, actual_code) }
+        passed_ops = opts.dup
+        passed_ops[:resource] ||= context.trace_name(klass)
+        passed_ops[:tags] ||= {}
+
+        InstrumentAllTheThings.tracer.trace(span_name, passed_ops) do
+          next_blk.call(klass, actual_code)
+        end
       end
     end
   end

--- a/lib/instrument_all_the_things/version.rb
+++ b/lib/instrument_all_the_things/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module InstrumentAllTheThings
-  VERSION = '1.0.4'
+  VERSION = '1.1.0'
 end

--- a/spec/tracing/instance_trace_spec.rb
+++ b/spec/tracing/instance_trace_spec.rb
@@ -102,6 +102,19 @@ RSpec.describe 'instance method tracing' do
     end
   end
 
+  describe 'arbitrary config' do
+    let(:trace_options) { { fooBaz: 'ddd' } }
+
+    it 'respects the configuration' do
+      expect(InstrumentAllTheThings.tracer).to receive(:trace).with(
+        anything,
+        a_hash_including(fooBaz: 'ddd'),
+      )
+
+      call_traced_method
+    end
+  end
+
   describe 'with tags' do
     let(:trace_options) { { tags: ['hey'] } }
 


### PR DESCRIPTION
This allows passing arbitrary hash keys and values to the trace method by including them in the trace key `instrument trace: { whatever: 123}` this functionality was dropped accidentally. It is used to suppress errors using the `on_error` callback